### PR TITLE
Add Sicily greenhouse parameter file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,8 +102,8 @@ cookiecutter-pypackage-env/
 # If you want, you can add some demo/dummy data by using git add -f data/...
 data/
 **/input_data/
-!**/input_data/.gitkeep
 !**/input_data/test_data
+!**/input_data/.gitkeep
 
 # Model output
 # Use <model_name>/output/ for storing model outputs. Like other data, this is not included in git

--- a/docs/using_greenlight.md
+++ b/docs/using_greenlight.md
@@ -221,6 +221,7 @@ into two files: one which runs the simulations, and another one which loads the 
 
 ## More examples
 The following examples are included in the GreenLight repository:
-- `scripts/greenlight_example` simple example, available as a a [Python script](../scripts/greenlight_example.py) and a [Jupyter notebook](../notebooks/greenlight_example.ipynb)
+- `scripts/greenlight_example` simple example, available as a [Python script](../scripts/greenlight_example.py) and a [Jupyter notebook](../notebooks/greenlight_example.ipynb)
+- [`scripts/greenlight_example_sicily`](../scripts/greenlight_example_sicily.py) example simulation of a low-tech (arch-shaped plastic multi-tunnel) in Sicily
 - [`scripts/katzin_2020/`](../scripts/katzin_2020/Readme.txt) Rerun the simulations from [Katzin (2020)](https://doi.org/10.1016/j.biosystemseng.2020.03.010) and reproduce the results
 - [`scripts/katzin_2021/`](../scripts/katzin_2021/Readme.txt) Rerun the simulations from [Katzin (2021a)](https://doi.org/10.1016/j.apenergy.2020.116019) and reproduce the results

--- a/greenlight/models/katzin_2021/definition/vanthoor_2011/greenhouse_params_vanthoor_2011_chapter_8_sicily.json
+++ b/greenlight/models/katzin_2021/definition/vanthoor_2011/greenhouse_params_vanthoor_2011_chapter_8_sicily.json
@@ -1,0 +1,618 @@
+{
+    "Info" : {
+      "About" : "This file includes the greenhouse properties of the greenhouse in Sicily described in Vanthoor 2011, Chapter 2 (also published as Vanthoor 2011a), and Chapter 8 (also published as the electronic appendix of Vanthoor 2011a). Specifically, this file includes the information about the greenhouse in Sicily described in Table 8.2 of Vanthoor 2011. According to Table 2.1 in Vanthoor 2011, this greenhouse is an arch-shape multi-tunnel greenhouse, with a double-inflated polyethylene (PE) cover, with whitewash, measuring 1.3 ha in area, with continuous roof ventilation on one side of each span, covered with insect netting. Note that Table 8.2 provides no information on the parameter psi for Sicily, therefore some assumptions were made (see \"psi\" below)",
+      "Usage" : "This file contains only the parameters included in Vanthoor 2011, Table 8.2 for the greenhouse in Sicily. It is meant to use in addition to the files describing the greenhouse, crop, and climate control (see folder vanthoor_2011). In order to disable the use of a thermal screen, this file forces the thermal screen control uThScr to be constantly 0 (see \"uThScr\" below)",
+      "References" : {
+         "Vanthoor 2011" : "Vanthoor, Bram (2011). A model-based greenhouse design method. PhD thesis, Wageningen University. https://edepot.wur.nl/170301",
+         "Vanthoor 2011a" : "Vanthoor, B. H. E., Stanghellini, C., van Henten, E. J., & de Visser, P. H. B. (2011). A methodology for model-based greenhouse design: Part 1, a greenhouse climate model for a broad range of designs and climates. Biosystems Engineering, 110(4), 363–377. https://doi.org/10.1016/j.biosystemseng.2011.06.001"
+      },
+      "Notation" : "Notation follows Vanthoor (2011)",
+      "Authors" : "This file was written by Cristina Zepeda & David Katzin (Wageningen University & Research)",
+      "Date" : "This file was created in July 2026",
+      "URL" : "https://github.com/davkat1/GreenLight",
+      "File" : "GreenLight/models/katzin_2021/definition/vanthoor_2011/greenhouse_params_vanthoor_2011_chapter_8_sicily.json"
+    },
+    "etaGlobAir": {
+        "definition": "0.1",
+        "type": "const",
+        "unit": "-",
+        "description": "Ratio of global radiation absorbed by the greenhouse construction",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "psi": {
+        "definition": "36",
+        "type": "const",
+        "unit": "°",
+        "description": "Mean greenhouse cover slope",
+        "reference": "psi is used to calculate the ratio between half a span and the length of the cross-cut of the cover (used as cos(psi),  Equation 8.18, Vanthoor 2011). Consider a Venlo-type greenhouse (Netherlands in Table 8.2, Vanthoor 2011) with a span width of 3.4 m (assumed), gutter height of 3.8 m, and ridge height of 4.6 m (average greenhouse height): ridge minus gutter is 0.8 m, half a span is 1.7, and the slope of the cover is arctan(0.8/1.7) = 25°. Now consider an arch-shaped greenhouse (Sicily in Table 8.2, Vanthoor 2011), with gutter height 4 m, max height 5.6 m (average height 4.8 m), and span width of 8 m (assumed). The length of the arch is assumed to be the average between a length in the case of a Venlo greenhouse and the case of a rectangular greenhouse. For the case of Venlo: psi is arctan(height/halfspan), where height is 5.6 - 4 = 1.6 m, and halfspan is 8/2 = 4, therefore psi=21.8°. Then the length is halfspan/cos(22°) = 4.3. For the case of rectangle: the length is halfspan+height = 1.6+4 = 5.6. The average of these two lengths is (4.3+5.6)/2 = 4.95 m. For this length, the associated psi is arccos(halfspan/length) = arctan(4/4.95) = 36°"
+    },
+    "aCov": {
+        "definition": "1.7e4",
+        "type": "const",
+        "unit": "m**2",
+        "description": "Surface of the cover including side walls",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "aFlr": {
+        "definition": "1.3e4",
+        "type": "const",
+        "unit": "m**2",
+        "description": "Floor area of greenhouse",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "cHecIn": {
+        "definition": "2.21",
+        "type": "const",
+        "unit": "W m**-2 K**-1",
+        "description": "Convective heat exchange between cover and outdoor air",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "cHecOut1": {
+        "definition": "0.95",
+        "type": "const",
+        "unit": "W m**-2{cover} K**-1",
+        "description": "Convective heat exchange parameter between cover and outdoor air",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "cHecOut2": {
+        "definition": "6.76",
+        "type": "const",
+        "unit": "J m**-3 K**-1",
+        "description": "Convective heat exchange parameter between cover and outdoor air",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "cHecOut3": {
+        "definition": "0.49",
+        "type": "const",
+        "unit": "-",
+        "description": "Convective heat exchange parameter between cover and outdoor air",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "hAir": {
+        "definition": "4",
+        "type": "const",
+        "unit": "m",
+        "description": "Height of the main compartment (below the screen)",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "hGh": {
+        "definition": "4.8",
+        "type": "const",
+        "unit": "m",
+        "description": "Mean height of the greenhouse",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "etaShScrCd": {
+        "definition": "0",
+        "type": "const",
+        "unit": "-",
+        "description": "Effect of shading screen on discharge coefficient",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily) - no shading screen"
+    },
+    "etaShScrCw": {
+        "definition": "0",
+        "type": "const",
+        "unit": "-",
+        "description": "Effect of shading screen on wind pressure coefficient",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily) - no shading screen"
+    },
+    "zetaInsScr": {
+        "definition": "0.33",
+        "type": "const",
+        "unit": "-",
+        "description": "Porosity of the insect screen",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "aRoof": {
+        "definition": "0.26e4",
+        "type": "const",
+        "unit": "-",
+        "description": "Roof ventilation area",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily). aFlr is 1.3e4 and aRoof/aFlr is 0.2, so aRoof = 0.2*1.3e4 = 0.26e4"
+    },
+    "aSide": {
+        "definition": "0",
+        "type": "const",
+        "unit": "-",
+        "description": "Side ventilation area",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "cDgh": {
+        "definition": "0.75",
+        "type": "const",
+        "unit": "-",
+        "description": "Ventilation discharge coefficient",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "cLeakage": {
+        "definition": "1e-4",
+        "type": "const",
+        "unit": "-",
+        "description": "Greenhouse leakage coefficient",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "cWgh": {
+        "definition": "0.12",
+        "type": "const",
+        "unit": "-",
+        "description": "Ventilation global wind pressure coefficient",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "hSideRoof": {
+        "definition": "1",
+        "type": "const",
+        "unit": "m",
+        "description": "Vertical distance between mid-points of side wall and roof ventilation openings",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily) - no side wall"
+    },
+    "hVent": {
+        "definition": "1.6",
+        "type": "const",
+        "unit": "m",
+        "description": "Vertical dimension of a single ventilation opening",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "epsRfFir": {
+        "definition": "0.9",
+        "type": "const",
+        "unit": "-",
+        "description": "FIR emission coefficient of the roof",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "rhoRf": {
+        "definition": "35",
+        "type": "const",
+        "unit": "kg m**-3",
+        "description": "Density of the roof layer",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "rhoRfNir": {
+        "definition": "0.21",
+        "type": "const",
+        "unit": "-",
+        "description": "NIR reflection coefficient of the roof",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "rhoRfPar": {
+        "definition": "0.21",
+        "type": "const",
+        "unit": "-",
+        "description": "PAR reflection coefficient of the roof",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "rhoRfFir": {
+        "definition": "0",
+        "type": "const",
+        "unit": "-",
+        "description": "FIR reflection coefficient of the roof",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "tauRfNir": {
+        "definition": "0.77",
+        "type": "const",
+        "unit": "-",
+        "description": "NIR transmission coefficient of the roof",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "tauRfPar": {
+        "definition": "0.77",
+        "type": "const",
+        "unit": "-",
+        "description": "PAR transmission coefficient of the roof",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "tauRfFir": {
+        "definition": "0.1",
+        "type": "const",
+        "unit": "-",
+        "description": "FIR transmission coefficient of the roof",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "lambdaRf": {
+        "definition": "0.018",
+        "type": "const",
+        "unit": "W m**-1 K**-1",
+        "description": "Thermal heat conductivity of the roof",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "cPRf": {
+        "definition": "2.5e3",
+        "type": "const",
+        "unit": "J K**-1 kg**-1",
+        "description": "Specific heat capacity of roof layer",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "hRf": {
+        "definition": "0.01",
+        "type": "const",
+        "unit": "m",
+        "description": "Thickness of roof layer",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "epsShScrPerFir": {
+        "definition": "0.9",
+        "type": "const",
+        "unit": "-",
+        "description": "FIR emission coefficient of the whitewash",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "rhoShScrPer": {
+        "definition": "1e3",
+        "type": "const",
+        "unit": "-",
+        "description": "Density of the whitewash",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "rhoShScrPerNir": {
+        "definition": "0.2",
+        "type": "const",
+        "unit": "-",
+        "description": "NIR reflection coefficient of whitewash",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "rhoShScrPerPar": {
+        "definition": "0.2",
+        "type": "const",
+        "unit": "-",
+        "description": "PAR reflection coefficient of whitewash",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "rhoShScrPerFir": {
+        "definition": "0",
+        "type": "const",
+        "unit": "-",
+        "description": "FIR reflection coefficient of whitewash",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "tauShScrPerNir": {
+        "definition": "0.7",
+        "type": "const",
+        "unit": "-",
+        "description": "NIR transmission coefficient of whitewash",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "tauShScrPerPar": {
+        "definition": "0.7",
+        "type": "const",
+        "unit": "-",
+        "description": "PAR transmission coefficient of whitewash",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "tauShScrPerFir": {
+        "definition": "0.1",
+        "type": "const",
+        "unit": "-",
+        "description": "FIR transmission coefficient of whitewash",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "lambdaShScrPer": {
+        "definition": "1e10",
+        "type": "const",
+        "unit": "W m**-1 K**-1",
+        "description": "Thermal heat conductivity of the whitewash",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily - value is Inf (or very high))"
+    },
+    "cPShScrPer": {
+        "definition": "4.18e3",
+        "type": "const",
+        "unit": "J K**-1 kg**-1",
+        "description": "Specific heat capacity of the whitewash",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "hShScrPer": {
+        "definition": "0.2e-3",
+        "type": "const",
+        "unit": "m",
+        "description": "Thickness of the whitewash",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "rhoShScrNir": {
+        "definition": "0",
+        "type": "const",
+        "unit": "-",
+        "description": "NIR reflection coefficient of shading screen",
+        "reference": "Assuming no shading screen"
+    },
+    "rhoShScrPar": {
+        "definition": "0",
+        "type": "const",
+        "unit": "-",
+        "description": "PAR reflection coefficient of shading screen",
+        "reference": "Assuming no shading screen"
+    },
+    "rhoShScrFir": {
+        "definition": "0",
+        "formatted definition": "0",
+        "type": "const",
+        "unit": "-",
+        "description": "FIR reflection coefficient of shading screen",
+        "reference": "Assuming no shading screen"
+    },
+    "tauShScrNir": {
+        "definition": "1",
+        "type": "const",
+        "unit": "-",
+        "description": "NIR transmission coefficient of shading screen",
+        "reference": "Assuming no shading screen"
+    },
+    "tauShScrPar": {
+        "definition": "1",
+        "type": "const",
+        "unit": "-",
+        "description": "PAR transmission coefficient of shading screen",
+        "reference": "Assuming no shading screen"
+    },
+    "tauShScrFir": {
+        "definition": "1",
+        "type": "const",
+        "unit": "-",
+        "description": "FIR transmission coefficient of shading screen",
+        "reference": "Assuming no shading screen"
+    },
+    "kShScr": {
+        "definition": "0",
+        "type": "const",
+        "unit": "m**3 m**-2 K**(2/3) s**-1",
+        "description": "shading screen flux coefficient",
+        "reference": "Assuming no shading screen"
+    },
+    "epsThScrFir": {
+        "definition": "0",
+        "type": "const",
+        "unit": "-",
+        "description": "FIR emissions coefficient of the thermal screen",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily) - no thermal screen"
+    },
+    "rhoThScr": {
+        "definition": "0.2e3",
+        "type": "const",
+        "unit": "kg m**-3",
+        "description": "Density of thermal screen",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily) - no thermal screen. This value can't be 0 because then the ODE's can't solve. Besides that, the value doesn't matter because there's no thermal screen"
+    },
+    "uThScr": {
+        "definition": "0",
+        "type": "aux",
+        "unit": "-",
+        "description": "Control of the thermal screen",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily) - no thermal screen"
+    },
+    "rhoThScrNir": {
+        "definition": "0",
+        "type": "const",
+        "unit": "-",
+        "description": "NIR reflection coefficient of thermal screen",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily) - no thermal screen"
+    },
+    "rhoThScrPar": {
+        "definition": "0",
+        "type": "const",
+        "unit": "-",
+        "description": "PAR reflection coefficient of thermal screen",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily) - no thermal screen"
+    },
+    "rhoThScrFir": {
+        "definition": "0",
+        "type": "const",
+        "unit": "-",
+        "description": "FIR reflection coefficient of thermal screen",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily) - no thermal screen"
+    },
+    "tauThScrNir": {
+        "definition": "1",
+        "type": "const",
+        "unit": "-",
+        "description": "NIR transmission coefficient of thermal screen",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily) - no thermal screen"
+    },
+    "tauThScrPar": {
+        "definition": "1",
+        "type": "const",
+        "unit": "-",
+        "description": "PAR transmission coefficient of thermal screen",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily) - no thermal screen"
+    },
+    "tauThScrFir": {
+        "definition": "1",
+        "type": "const",
+        "unit": "-",
+        "description": "FIR transmission coefficient of thermal screen",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily) - no thermal screen"
+    },
+    "cPThScr": {
+        "definition": "1.8e3",
+        "type": "const",
+        "unit": "J kg**-1 K**-1",
+        "description": "Specific heat capacity of thermal screen",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily) - no thermal screen. This value can't be 0 because then the ODE's can't solve. Besides that, the value doesn't matter because there's no thermal screen"
+    },
+    "hThScr": {
+        "definition": "0.35e-3",
+        "type": "const",
+        "unit": "m",
+        "description": "Thickness of thermal screen",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily) - no thermal screen. This value can't be 0 because then the ODE's can't solve. Besides that, the value doesn't matter because there's no thermal screen"
+    },
+    "kThScr": {
+        "definition": "0",
+        "type": "const",
+        "unit": "m**3 m**-2 K**(2/3) s**-1",
+        "description": "Thermal screen flux coefficient",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily) - no thermal screen"
+    },
+    "epsFlr": {
+        "definition": "1",
+        "type": "const",
+        "unit": "-",
+        "description": "FIR emission coefficient of the floor",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "rhoFlr": {
+        "definition": "2300",
+        "type": "const",
+        "unit": "kg m**-3",
+        "description": "Density of the floor",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "rhoFlrNir": {
+        "definition": "0.5",
+        "type": "const",
+        "unit": "-",
+        "description": "NIR reflection coefficient of the floor",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "rhoFlrPar": {
+        "definition": "0.65",
+        "type": "const",
+        "unit": "-",
+        "description": "PAR reflection coefficient of the floor",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "lambdaFlr": {
+        "definition": "1.7",
+        "type": "const",
+        "unit": "W m**-1 K**-1",
+        "description": "Thermal heat conductivity of the floor",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "cPFlr": {
+        "definition": "0.88e3",
+        "type": "const",
+        "unit": "J kg**-1 K**-1",
+        "description": "Specific heat capacity of the floor",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "hFlr": {
+        "definition": "0.02",
+        "type": "const",
+        "unit": "m",
+        "description": "Thickness of floor",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "rhoCpSo": {
+        "definition": "1.73e6",
+        "type": "const",
+        "unit": "J m**-3 K**-1",
+        "description": "Volumetric heat capacity of the soil",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "lambdaSo": {
+        "definition": "0.85",
+        "type": "const",
+        "unit": "W m**-1 K**-1",
+        "description": "Thermal heat conductivity of the soil layers",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "epsPipe": {
+        "definition": "0.88",
+        "type": "const",
+        "unit": "-",
+        "description": "FIR emission coefficient of the heating pipes",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "phiPipeE": {
+        "definition": "51e-3",
+        "type": "const",
+        "unit": "m",
+        "description": "External diameter of heating pipes",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "phiPipeI": {
+        "definition": "47e-3",
+        "type": "const",
+        "unit": "m",
+        "description": "Internal diameter of heating pipes",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily)"
+    },
+    "lPipe": {
+        "definition": "1.25",
+        "type": "const",
+        "unit": "m m**-2",
+        "description": "Length of heating pipes per greenhouse floor area",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily). Note that it's possible for a greenhouse to have heating pipes but no heating, in this case the pipes are used as rails for the trolleys in the greenhouse"
+    },
+    "etaPad": {
+        "definition": "0",
+        "type": "const",
+        "unit": "-",
+        "description": "Efficiency of the pad and fan system",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily) - no pad and fan"
+    },
+    "phiFog": {
+        "definition": "0",
+        "type": "const",
+        "unit": "kg {water} s**-1",
+        "description": "Capacity of the fogging system",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily) - no fogging"
+    },
+    "phiPad": {
+        "definition": "0",
+        "type": "const",
+        "unit": "m**3 s**-1",
+        "description": "Capacity of the air flux through the pad and fan",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily) - no pad and fan"
+    },
+    "phiVentForced": {
+        "definition": "0",
+        "type": "const",
+        "unit": "m**3 s**-1",
+        "description": "Air flow capacity of the forced ventilation system",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily) - no forced ventilation"
+    },
+    "phiExtCo2": {
+        "definition": "0",
+        "type": "const",
+        "unit": "mg s**-1",
+        "description": "Capacity of external CO2 source",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily) - no external CO2"
+    },
+    "copMechCool": {
+        "definition": "0",
+        "type": "const",
+        "unit": "-",
+        "description": "Coefficient of performance of the mechanical cooling system",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily) - no mechanical cooling"
+    },
+    "hecPasAir": {
+        "definition": "0",
+        "type": "const",
+        "unit": "W m**-2 K**-1",
+        "description": "Convective heat exchange coefficient between passive heat storage and greenhouse air",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily) - no heat storage"
+    },
+    "pBlow": {
+        "definition": "0",
+        "type": "const",
+        "unit": "W",
+        "description": "Heat capacity of heat blowers",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily) - no heat blowers"
+    },
+    "pBoil": {
+        "definition": "0",
+        "type": "const",
+        "unit": "W",
+        "description": "Heat capacity of boiler",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily) - no boiler. Note that it's possible for a greenhouse to have heating pipes but no heating, in this case the pipes are used as rails for the trolleys in the greenhouse"
+    },
+    "pGeo": {
+        "definition": "0",
+        "type": "const",
+        "unit": "W",
+        "description": "Heat capacity of geothermal heat source",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily) - no geothermal heat"
+    },
+    "pInd": {
+        "definition": "0",
+        "type": "const",
+        "unit": "W",
+        "description": "Heat capacity of industrial heat source",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily) - no industrial heat"
+    },
+    "pMechCool": {
+        "definition": "0",
+        "type": "const",
+        "unit": "W",
+        "description": "Electrical capacity of mechanical cooling system",
+        "reference": "Vanthoor 2011, Table 8.2 (Sicily) - no mechanical cooling"
+    }
+}

--- a/greenlight/models/katzin_2021/definition/vanthoor_2011/main_vanthoor_2011_sicily.json
+++ b/greenlight/models/katzin_2021/definition/vanthoor_2011/main_vanthoor_2011_sicily.json
@@ -1,0 +1,24 @@
+{
+   "info" : {
+      "about" : "Run the Vanthoor (2011) greenhouse and tomato crop model, with some modifications by Katzin (2021), and climate control according to Katzin (2021).",
+      "usage" : "In order to run a meaningful simulation, climate data must be provided. In this example, climate inputs are taken from EnergyPlus, see vanthoor_2011\\readme.txt. Use the name of the generated weather file as the fourth line in processing_order, below. The simulation length is set to 350 days = 60x60x24x120 = 30240000 seconds",
+      "References" : {
+         "Vanthoor 2011" : "Vanthoor, Bram (2011). A model-based greenhouse design method. PhD thesis, Wageningen University. https://edepot.wur.nl/170301",
+         "Katzin 2021" : "Katzin, David (2021). Energy Saving by LED Lighting in Greenhouses : A Process-Based Modelling Approach. PhD thesis, Wageningen University. https://doi.org/10.18174/544434"
+      },
+      "author" : "This file was written by David Katzin, Wageningen University and Research. david.katzin@wur.nl",
+      "created" : "May 2025",
+      "URL" : "https://github.com/davkat1/GreenLight",
+      "File" : "GreenLight/models/katzin_2021/definition/vanthoor_2011/main_vanthoor_2011.json"
+   },
+   "processing_order" : [
+      "greenhouse_vanthoor_2011_chapter_8.json",
+      "crop_vanthoor_2011_chapter_9_simplified.json",
+      "controls_katzin_2021.json",
+      "greenhouse_params_vanthoor_2011_chapter_8_sicily.json",
+      {"options" : {
+         "t_start" : "0",
+         "t_end" : "30240000"
+      }}
+   ]
+}

--- a/scripts/greenlight_example_sicily.py
+++ b/scripts/greenlight_example_sicily.py
@@ -1,0 +1,204 @@
+"""
+GreenLight/scripts/greenlight_example_sicily.py
+Copyright (c) 2025 David Katzin, Wageningen Research Foundation
+SPDX-License-Identifier: BSD-3-Clause-Clear
+https://github.com/davkat1/GreenLight
+
+An example script on how to use greenlight to run a greenhouse simulation, then view and analyze some of the results.
+In this example, an arch-shaped polyethylene multi-tunnel (The "Sicily" greenhouse of Vanthoor 2011) is used.
+Note: in order to get meaningful results, weather data (such as EnergyPlus data) should be included.
+The same procedure that works for the main program also applies here,
+see docs/input_data.md#acquiring-input-data-for-the-greenlightmain-program
+"""
+
+import datetime as dt
+import os
+import sys
+import warnings
+
+import matplotlib
+import pandas as pd
+
+import greenlight
+
+# Detect headless environment and set backend accordingly
+if not os.environ.get("DISPLAY"):
+    matplotlib.use("Agg")  # Headless (no display)
+else:
+    matplotlib.use("TkAgg")  # Interactive
+
+import matplotlib.pyplot as plt  # noqa: E402
+
+# Model simulation settings
+output_file_name = "greenlight_example_sicily_output.csv"  # Chosen name for the file that will contain the simulation output
+original_energyPlus_csv = "ITA_Catania-Sigonella.164590_IGDGEPW.csv"  # Name of the unprocessed EnergyPlus CSV
+formatted_csv_name = "weather_cat_katzin_2021.csv"  # Chosen name for the processed EnergyPlus data
+start_date = dt.datetime(year=2020, month=10, day=1)  # First day of simulation season
+simulation_length = 3  # Length of simulated season, in days
+
+# Set up directories
+if "__file__" in locals():  # Running this from script
+    project_dir = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
+else:
+    project_dir = os.getcwd()  # Most likely the active directory is the project directory
+sys.path.append(project_dir)
+
+# Base directory to be used by the model
+base_path = os.path.join(project_dir, "greenlight", "models")
+
+# Location (relative to base_path) of the main definition of the Katzin 2021 model, which will be used here
+model = os.path.join("katzin_2021", "definition", "vanthoor_2011", "main_vanthoor_2011_sicily.json")
+
+# Location of weather files, relative to base_path
+original_file_directory = os.path.join("katzin_2021", "input_data", "energyPlus_original")
+formatted_file_directory = os.path.join("katzin_2021", "input_data", "energyPlus_formatted")
+
+# Modify directories to absolute path
+original_file_directory = os.path.abspath(os.path.join(base_path, original_file_directory))
+formatted_file_directory = os.path.abspath(os.path.join(base_path, formatted_file_directory))
+
+# Outputs will be placed under katzin_2021/output
+output_dir = os.path.join("katzin_2021", "output")
+
+""" Simulation settings """
+# Numbers of days to simulate, in seconds
+options = {"options": {"t_end": str(simulation_length * 24 * 3600)}}
+
+# Any other modification to the model
+mods = [{"thetaLampMax": {"definition": "120"}}]  # Change the maximum lamp intensity to 120 W/m2
+
+""" Add weather data """
+# Convert original file into formatted file - with the required start and end date
+
+# Weather data to use in case formatting the input weather data doesn't work
+fallback_directory = os.path.abspath(os.path.join(base_path, os.path.join("katzin_2021", "input_data", "test_data")))
+fallback_file = "Bleiswijk_from_20091020.csv"
+try:
+    formatted_file_name = greenlight.convert_energy_plus(
+        os.path.join(original_file_directory, original_energyPlus_csv),
+        os.path.join(formatted_file_directory, formatted_csv_name),
+        t_out_start=start_date,
+        t_out_end=start_date + dt.timedelta(days=simulation_length),
+    )
+    mods.append(os.path.join(formatted_file_directory, formatted_file_name))
+except FileNotFoundError:
+    warnings.warn(
+        "Couldn't find file:\n"
+        f"{os.path.abspath(os.path.join(original_file_directory, original_energyPlus_csv))}\n"
+        "Using built-in weather data instead"
+    )
+
+    # Use built-in weather data
+    formatted_file_directory = fallback_directory
+    formatted_file_name = fallback_file
+except Exception:
+    warnings.warn(
+        "Failed to convert EnergyPlus file:\n"
+        f"{os.path.abspath(os.path.join(original_file_directory, original_energyPlus_csv))}\n"
+        "To formatted file:\n"
+        f"{os.path.abspath(os.path.join(formatted_file_directory, formatted_csv_name))}\n"
+    )
+
+    # Use built-in weather data
+    formatted_file_directory = fallback_directory
+    formatted_file_name = fallback_file
+    if os.path.exists(os.path.join(formatted_file_directory, formatted_file_name)):
+        warnings.warn(
+            f"Fallback weather data file not found. \
+            file:{os.path.join(formatted_file_directory, formatted_file_name)}.\
+            Using built-in weather data"
+        )
+        mods.append(os.path.join(formatted_file_directory, formatted_file_name))
+    else:
+        warnings.warn(
+            f"Fallback weather data file not found. \
+            file:{os.path.join(formatted_file_directory, formatted_file_name)}.\
+            Running without weather data"
+        )
+
+
+"""Run the model"""
+input_arg = [model, options, mods]
+output_arg = os.path.join(output_dir, output_file_name)
+mdl = greenlight.GreenLight(base_path=base_path, input_prompt=input_arg, output_path=output_arg)
+mdl.run()
+
+"""Load simulation result"""
+output_df = pd.read_csv(os.path.join(base_path, output_dir, output_file_name), header=None, low_memory=False)
+variable_names = output_df.iloc[0]
+descriptions = output_df.iloc[1]
+units = output_df.iloc[2]
+
+# Reformat the DataFrame with variable names as columns
+output_df = output_df.iloc[3:].reset_index(drop=True).apply(pd.to_numeric)
+output_df.columns = variable_names
+
+# Create dictionaries for descriptions and units
+descriptions_dict = dict(zip(variable_names, descriptions))
+units_dict = dict(zip(variable_names, units))
+
+"""Show some graphs"""
+# Choose variables out of output_df.columns
+# For a description of a variable var, see descriptions_dict[var]. For the unit, see units_dict[var]
+chosen_vars = ["tOut", "tAir", "tCan", "lai", "cFruit", "mcFruitHar", "hBoilPipe"]
+
+for var in chosen_vars:
+    fig, ax = plt.subplots()
+    output_df.plot(
+        x="Time",
+        y=var,
+        xlabel="Time (s)",
+        ylabel=f"{var} ({units_dict[var]})",
+        title=descriptions_dict[var],
+        legend=None,
+        ax=ax,
+    )
+    import errno
+
+    # Check if running in headless mode (no display)
+    headless = matplotlib.get_backend().lower() == "agg"
+
+    if headless:
+        # Generate the plots in /plots folder instead of showing them
+
+        # Save plots to the same directory as the output file
+        plots_dir = os.path.join(base_path, output_dir, "plots")
+        try:
+            os.makedirs(plots_dir, exist_ok=True)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise
+        plot_path = os.path.join(plots_dir, f"{var}.png")
+        fig.savefig(plot_path)
+        print(f"Plot for {var} saved to {plot_path}")
+    else:
+        plt.show()
+
+""" Calculate yield, energy use, CO2 use, water use """
+# The time steps (in s) in the output data
+time_step = output_df.loc[1, "Time"] - output_df.loc[0, "Time"]
+print(f"Time step size: {time_step} seconds")
+print(f'Simulation length: {(output_df["Time"].iloc[-1] - output_df["Time"].iloc[0]) / 86400} days')
+
+# Assumed fruit dry matter content
+dmc = 0.06
+
+# Total yield, kg fresh weight per m**2
+tot_yield = time_step * sum(output_df["mcFruitHar"]) * 1e-6 / dmc
+print(f"Yield: {tot_yield} kg/m2")
+
+# Energy for heating, MJ m**2
+energy_heat = time_step * sum(output_df["hBoilPipe"])  * 1e-6
+print(f"Energy used for heating: {energy_heat} MJ/m2")
+
+# Total CO2 use (for CO2 injection), kg m**2
+tot_co2 = time_step * sum(output_df["mcExtAir"]) * 1e-6
+print(f"CO2 use: {tot_co2} kg/m2")
+
+# Assumed ratio between total transpiration and total irrigation
+# If drain is recirculated, transpiration is about 90% of irrigation, irrigation is about 1.1 times transpiration
+trans_to_irrig = 1.1
+
+# Total water use (for irrigation), kg m**2
+tot_h20 = time_step * trans_to_irrig * sum(output_df["mvCanAir"])
+print(f"Water use for irrigation: {tot_h20} liters/m2")


### PR DESCRIPTION
Add a parameter file (and a simple example) describing a low-tech (arch-shaped plastic multi-tunnel) greenhouse, based on the greenhouse in Sicily described in Vanthoor (2011), Table 8.2.
- **`greenlight/models/katzin_2021/definition/vanthoor_2011/greenhouse_params_vanthoor_2011_chapter_8_sicily.json`**: Parameter file following Vanthoor (2011), Table 8.2, low-tech greenhouse in Sicily
- **`greenlight/models/katzin_2021/definition/vanthoor_2011/main_vanthoor_2011_sicily.json`**: main simulation file, showing how `greenhouse_params_vanthoor_2011_chapter_8_sicily.json` can be integrated with the rest of the model
-  **`scripts/greenlight_example_sicily.py`**: example how to run a simulation with such a greenhouse

Authors: Cristina Zepeda & David Katzin, Wageningen University & Research